### PR TITLE
feat(i18n): add internationalization support with vue-i18n (READY)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "i18n-ally.localesPaths": [
+        "src/locales"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -12,14 +12,19 @@
   "dependencies": {
     "jszip": "^3.10.1",
     "monaco-editor": "^0.53.0",
-    "vue": "^3.5.21"
+    "vue": "^3.5.21",
+    "vue-i18n": "^11.1.12"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^20.11.30",
-    "vite-plugin-pwa": "^1.0.3",
     "@vitejs/plugin-vue": "^6.0.1",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.13",
     "typescript": "^5.4.0",
     "vite": "^7.1.5",
+    "vite-plugin-pwa": "^1.0.3",
     "vue-tsc": "^3.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,27 +17,46 @@ importers:
       vue:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.9.2)
+      vue-i18n:
+        specifier: ^11.1.12
+        version: 11.1.12(vue@3.5.21(typescript@5.9.2))
     devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.13
+        version: 4.1.13
       '@types/node':
         specifier: ^20.11.30
         version: 20.19.13
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@7.1.5(@types/node@20.19.13)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))
+        version: 6.0.1(vite@7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))
+      autoprefixer:
+        specifier: ^10.4.21
+        version: 10.4.21(postcss@8.5.6)
+      postcss:
+        specifier: ^8.5.6
+        version: 8.5.6
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.1.13
       typescript:
         specifier: ^5.4.0
         version: 5.9.2
       vite:
         specifier: ^7.1.5
-        version: 7.1.5(@types/node@20.19.13)(terser@5.44.0)
+        version: 7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)
       vite-plugin-pwa:
         specifier: ^1.0.3
-        version: 1.0.3(vite@7.1.5(@types/node@20.19.13)(terser@5.44.0))(workbox-build@7.3.0)(workbox-window@7.3.0)
+        version: 1.0.3(vite@7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(workbox-build@7.3.0)(workbox-window@7.3.0)
       vue-tsc:
         specifier: ^3.0.6
         version: 3.0.6(typescript@5.9.2)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@apideck/better-ajv-errors@0.3.6':
     resolution: {integrity: sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA==}
@@ -696,6 +715,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@intlify/core-base@11.1.12':
+    resolution: {integrity: sha512-whh0trqRsSqVLNEUCwU59pyJZYpU8AmSWl8M3Jz2Mv5ESPP6kFh4juas2NpZ1iCvy7GlNRffUD1xr84gceimjg==}
+    engines: {node: '>= 16'}
+
+  '@intlify/message-compiler@11.1.12':
+    resolution: {integrity: sha512-Fv9iQSJoJaXl4ZGkOCN1LDM3trzze0AS2zRz2EHLiwenwL6t0Ki9KySYlyr27yVOj5aVz0e55JePO+kELIvfdQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.1.12':
+    resolution: {integrity: sha512-Om86EjuQtA69hdNj3GQec9ZC0L0vPSAnXzB3gP/gyJ7+mA7t06d9aOAiqMZ+xEOsumGP4eEBlfl8zF2LOTzf2A==}
+    engines: {node: '>= 16'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -875,6 +910,94 @@ packages:
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
+  '@tailwindcss/node@4.1.13':
+    resolution: {integrity: sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.13':
+    resolution: {integrity: sha512-BrpTrVYyejbgGo57yc8ieE+D6VT9GOgnNdmh5Sac6+t0m+v+sKQevpFVpwX3pBrM2qKrQwJ0c5eDbtjouY/+ew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.13':
+    resolution: {integrity: sha512-YP+Jksc4U0KHcu76UhRDHq9bx4qtBftp9ShK/7UGfq0wpaP96YVnnjFnj3ZFrUAjc5iECzODl/Ts0AN7ZPOANQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.13':
+    resolution: {integrity: sha512-aAJ3bbwrn/PQHDxCto9sxwQfT30PzyYJFG0u/BWZGeVXi5Hx6uuUOQEI2Fa43qvmUjTRQNZnGqe9t0Zntexeuw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.13':
+    resolution: {integrity: sha512-Wt8KvASHwSXhKE/dJLCCWcTSVmBj3xhVhp/aF3RpAhGeZ3sVo7+NTfgiN8Vey/Fi8prRClDs6/f0KXPDTZE6nQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.13':
+    resolution: {integrity: sha512-mbVbcAsW3Gkm2MGwA93eLtWrwajz91aXZCNSkGTx/R5eb6KpKD5q8Ueckkh9YNboU8RH7jiv+ol/I7ZyQ9H7Bw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.13':
+    resolution: {integrity: sha512-wdtfkmpXiwej/yoAkrCP2DNzRXCALq9NVLgLELgLim1QpSfhQM5+ZxQQF8fkOiEpuNoKLp4nKZ6RC4kmeFH0HQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
+    resolution: {integrity: sha512-hZQrmtLdhyqzXHB7mkXfq0IYbxegaqTmfa1p9MBj72WPoDD3oNOh1Lnxf6xZLY9C3OV6qiCYkO1i/LrzEdW2mg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
+    resolution: {integrity: sha512-uaZTYWxSXyMWDJZNY1Ul7XkJTCBRFZ5Fo6wtjrgBKzZLoJNrG+WderJwAjPzuNZOnmdrVg260DKwXCFtJ/hWRQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.13':
+    resolution: {integrity: sha512-oXiPj5mi4Hdn50v5RdnuuIms0PVPI/EG4fxAfFiIKQh5TgQgX7oSuDWntHW7WNIi/yVLAiS+CRGW4RkoGSSgVQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.13':
+    resolution: {integrity: sha512-+LC2nNtPovtrDwBc/nqnIKYh/W2+R69FA0hgoeOn64BdCX522u19ryLh3Vf3F8W49XBcMIxSe665kwy21FkhvA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.13':
+    resolution: {integrity: sha512-dziTNeQXtoQ2KBXmrjCxsuPk3F3CQ/yb7ZNZNA+UkNTeiTGgfeh+gH5Pi7mRncVgcPD2xgHvkFCh/MhZWSgyQg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.13':
+    resolution: {integrity: sha512-3+LKesjXydTkHk5zXX01b5KMzLV1xl2mcktBJkje7rhFUpUlYJy7IMOLqjIRQncLTa1WZZiFY/foAeB5nmaiTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.13':
+    resolution: {integrity: sha512-CPgsM1IpGRa880sMbYmG1s4xhAy3xEt1QULgTJGQmZUeNgXFR7s1YxYygmJyBGtou4SyEosGAGEeYqY7R53bIA==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.13':
+    resolution: {integrity: sha512-HLgx6YSFKJT7rJqh9oJs/TkBFhxuMOfUKSBEPYwV+t78POOBsdQ7crhZLzwcH3T0UyUuOzU/GK5pk5eKr3wCiQ==}
+
   '@types/estree@0.0.39':
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
 
@@ -923,6 +1046,9 @@ packages:
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/language-core@3.0.6':
     resolution: {integrity: sha512-e2RRzYWm+qGm8apUHW1wA5RQxzNhkqbbKdbKhiDUcmMrNAZGyM8aTiL3UrTqkaFI5s7wJRGGrp4u3jgusuBp2A==}
@@ -979,6 +1105,13 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  autoprefixer@10.4.21:
+    resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1029,6 +1162,10 @@ packages:
 
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1092,6 +1229,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  detect-libc@2.1.0:
+    resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
+    engines: {node: '>=8'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1103,6 +1244,10 @@ packages:
 
   electron-to-chromium@1.5.217:
     resolution: {integrity: sha512-Pludfu5iBxp9XzNl0qq2G87hdD17ZV7h5T4n6rQXDi3nCyloBV3jreE9+8GC6g4X/5yxqVgXEURpcLtM0WS4jA==}
+
+  enhanced-resolve@5.18.3:
+    resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
+    engines: {node: '>=10.13.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1175,6 +1320,9 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fraction.js@4.3.7:
+    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -1390,6 +1538,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jiti@2.5.1:
+    resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1431,6 +1583,70 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lightningcss-darwin-arm64@1.30.1:
+    resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.1:
+    resolution: {integrity: sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.1:
+    resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    resolution: {integrity: sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.1:
+    resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    resolution: {integrity: sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.1:
+    resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -1460,6 +1676,19 @@ packages:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
 
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   monaco-editor@0.53.0:
     resolution: {integrity: sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==}
 
@@ -1476,6 +1705,10 @@ packages:
 
   node-releases@2.0.20:
     resolution: {integrity: sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==}
+
+  normalize-range@0.1.2:
+    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1523,6 +1756,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -1705,6 +1941,17 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tailwindcss@4.1.13:
+    resolution: {integrity: sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==}
+
+  tapable@2.2.3:
+    resolution: {integrity: sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg==}
+    engines: {node: '>=6'}
+
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
+
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
@@ -1849,6 +2096,12 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-i18n@11.1.12:
+    resolution: {integrity: sha512-BnstPj3KLHLrsqbVU2UOrPmr0+Mv11bsUZG0PyCOzsawCivk8W00GMXHeVUWIDOgNaScCuZah47CZFE+Wnl8mw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-tsc@3.0.6:
     resolution: {integrity: sha512-Tbs8Whd43R2e2nxez4WXPvvdjGbW24rOSgRhLOHXzWiT4pcP4G7KeWh0YCn18rF4bVwv7tggLLZ6MJnO6jXPBg==}
     hasBin: true
@@ -1940,7 +2193,13 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
 snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@apideck/better-ajv-errors@0.3.6(ajv@8.17.1)':
     dependencies:
@@ -2681,6 +2940,22 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
+  '@intlify/core-base@11.1.12':
+    dependencies:
+      '@intlify/message-compiler': 11.1.12
+      '@intlify/shared': 11.1.12
+
+  '@intlify/message-compiler@11.1.12':
+    dependencies:
+      '@intlify/shared': 11.1.12
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.1.12': {}
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2825,6 +3100,78 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
+  '@tailwindcss/node@4.1.13':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.18.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
+      magic-string: 0.30.19
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.13
+
+  '@tailwindcss/oxide-android-arm64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.13':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.13':
+    dependencies:
+      detect-libc: 2.1.0
+      tar: 7.4.3
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.13
+      '@tailwindcss/oxide-darwin-arm64': 4.1.13
+      '@tailwindcss/oxide-darwin-x64': 4.1.13
+      '@tailwindcss/oxide-freebsd-x64': 4.1.13
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.13
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.13
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.13
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.13
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.13
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.13
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
+
+  '@tailwindcss/postcss@4.1.13':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.13
+      '@tailwindcss/oxide': 4.1.13
+      postcss: 8.5.6
+      tailwindcss: 4.1.13
+
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.8': {}
@@ -2839,10 +3186,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@vitejs/plugin-vue@6.0.1(vite@7.1.5(@types/node@20.19.13)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))':
+  '@vitejs/plugin-vue@6.0.1(vite@7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 7.1.5(@types/node@20.19.13)(terser@5.44.0)
+      vite: 7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)
       vue: 3.5.21(typescript@5.9.2)
 
   '@volar/language-core@2.4.23':
@@ -2891,6 +3238,8 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/language-core@3.0.6(typescript@5.9.2)':
     dependencies:
@@ -2961,6 +3310,16 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  autoprefixer@10.4.21(postcss@8.5.6):
+    dependencies:
+      browserslist: 4.25.4
+      caniuse-lite: 1.0.30001741
+      fraction.js: 4.3.7
+      normalize-range: 0.1.2
+      picocolors: 1.1.1
+      postcss: 8.5.6
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -3028,6 +3387,8 @@ snapshots:
 
   caniuse-lite@1.0.30001741: {}
 
+  chownr@3.0.0: {}
+
   commander@2.20.3: {}
 
   common-tags@1.8.2: {}
@@ -3084,6 +3445,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  detect-libc@2.1.0: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3095,6 +3458,11 @@ snapshots:
       jake: 10.9.4
 
   electron-to-chromium@1.5.217: {}
+
+  enhanced-resolve@5.18.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.2.3
 
   entities@4.5.0: {}
 
@@ -3230,6 +3598,8 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fraction.js@4.3.7: {}
 
   fs-extra@9.1.0:
     dependencies:
@@ -3458,6 +3828,8 @@ snapshots:
       filelist: 1.0.4
       picocolors: 1.1.1
 
+  jiti@2.5.1: {}
+
   js-tokens@4.0.0: {}
 
   jsesc@3.0.2: {}
@@ -3491,6 +3863,51 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss@1.30.1:
+    dependencies:
+      detect-libc: 2.1.0
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.30.1
+      lightningcss-darwin-x64: 1.30.1
+      lightningcss-freebsd-x64: 1.30.1
+      lightningcss-linux-arm-gnueabihf: 1.30.1
+      lightningcss-linux-arm64-gnu: 1.30.1
+      lightningcss-linux-arm64-musl: 1.30.1
+      lightningcss-linux-x64-gnu: 1.30.1
+      lightningcss-linux-x64-musl: 1.30.1
+      lightningcss-win32-arm64-msvc: 1.30.1
+      lightningcss-win32-x64-msvc: 1.30.1
+
   lodash.debounce@4.0.8: {}
 
   lodash.sortby@4.7.0: {}
@@ -3519,6 +3936,14 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minipass@7.1.2: {}
+
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
+  mkdirp@3.0.1: {}
+
   monaco-editor@0.53.0:
     dependencies:
       '@types/trusted-types': 1.0.6
@@ -3530,6 +3955,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   node-releases@2.0.20: {}
+
+  normalize-range@0.1.2: {}
 
   object-inspect@1.13.4: {}
 
@@ -3569,6 +3996,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -3832,6 +4261,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tailwindcss@4.1.13: {}
+
+  tapable@2.2.3: {}
+
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
+
   temp-dir@2.0.0: {}
 
   tempy@0.6.0:
@@ -3930,18 +4372,18 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-pwa@1.0.3(vite@7.1.5(@types/node@20.19.13)(terser@5.44.0))(workbox-build@7.3.0)(workbox-window@7.3.0):
+  vite-plugin-pwa@1.0.3(vite@7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0))(workbox-build@7.3.0)(workbox-window@7.3.0):
     dependencies:
       debug: 4.4.1
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
-      vite: 7.1.5(@types/node@20.19.13)(terser@5.44.0)
+      vite: 7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)
       workbox-build: 7.3.0
       workbox-window: 7.3.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@7.1.5(@types/node@20.19.13)(terser@5.44.0):
+  vite@7.1.5(@types/node@20.19.13)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3952,9 +4394,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.13
       fsevents: 2.3.3
+      jiti: 2.5.1
+      lightningcss: 1.30.1
       terser: 5.44.0
 
   vscode-uri@3.1.0: {}
+
+  vue-i18n@11.1.12(vue@3.5.21(typescript@5.9.2)):
+    dependencies:
+      '@intlify/core-base': 11.1.12
+      '@intlify/shared': 11.1.12
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.21(typescript@5.9.2)
 
   vue-tsc@3.0.6(typescript@5.9.2):
     dependencies:
@@ -4137,3 +4588,5 @@ snapshots:
   wrappy@1.0.2: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
     </svg>
   </button>
   <transition name="dropdown">
-    <div v-if="showDropdown" class="language-dropdown absolute right-0 w-64 bg-gray-800 rounded-lg shadow-xl py-2 z-10 max-h-[80vh] overflow-y-auto border border-gray-700"
+    <div v-if="showDropdown" class="language-dropdown absolute right-0 w-72 bg-gray-800 rounded-lg shadow-xl py-2 z-10 max-h-[80vh] overflow-y-auto border border-gray-700"
          :class="dropdownPosition === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'">
       <button 
         v-for="(name, code) in languages" 
@@ -70,19 +70,19 @@ const folderInput = ref<HTMLInputElement | null>(null)
 const zipInput = ref<HTMLInputElement | null>(null)
 
 const languages = {
-  en: 'English',
-  ru: 'Русский',
-  uk: 'Українська',
-  de: 'Deutsch',
-  'zh-CN': '简体中文',
-  'zh-TW': '繁體中文',
-  pl: 'Polski',
-  'en-US': 'American English',
-  es: 'Español',
-  ja: '日本語',
-  ko: '한국어',
-  'pt-BR': 'Português (Brasil)',
-  pt: 'Português'
+  en: '🇬🇧 English',
+  ru: '🇷🇺 Русский',
+  uk: '🇺🇦 Українська',
+  de: '🇩🇪 Deutsch',
+  'zh-CN': '🇨🇳 简体中文',
+  'zh-TW': '🇹🇼 繁體中文',
+  pl: '🇵🇱 Polski',
+  'en-US': '🇺🇸 American English',
+  es: '🇪🇸 Español',
+  ja: '🇯🇵 日本語',
+  ko: '🇰🇷 한국어',
+  'pt-BR': '🇧🇷 Português (Brasil)',
+  pt: '🇵🇹 Português'
 }
 const currentLanguageName = computed(() => languages[locale.value] || 'English')
 
@@ -228,6 +228,55 @@ header h1 {
   position: relative;
   margin-left: 16px;
   margin-right: 16px;
+}
+
+.language-toggle-btn {
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+  background: linear-gradient(to bottom, #3a3a3a, #2a2a2a);
+  color: white;
+  font-weight: 500;
+  border: 1px solid #444;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.language-toggle-btn::before {
+  content: '🌐';
+  font-size: 16px;
+}
+
+.language-dropdown {
+  border-radius: 12px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.35);
+  background: #1a1a1a;
+  border: 1px solid #333;
+  width: 280px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.language-option {
+  border-radius: 8px;
+  margin: 4px;
+  padding: 10px 16px;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.language-option:hover {
+  background-color: #2a2a2a;
+  transform: translateX(2px);
+}
+
+.language-option.bg-gradient-to-r {
+  box-shadow: 0 2px 8px rgba(59,130,246,0.4);
+  border-left: 2px solid #4d8bf8;
 }
 .dropdown-enter-active, .dropdown-leave-active {
   transition: opacity 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,17 +10,27 @@
         <button @click="pickDirectory" class="action-btn">{{ $t('openFolder') }}</button>
       </div>
       <div class="languages relative">
-        <button @click="toggleDropdown" class="bg-gray-700 text-white px-3 py-1 rounded flex items-center gap-1 hover:bg-gray-600 transition duration-200">
-          {{ currentLanguageName }} <span class="text-xs">▼</span>
-        </button>
-        <transition name="dropdown">
-          <div v-if="showDropdown" class="absolute top-full right-0 mt-1 bg-gray-800 border border-gray-600 rounded shadow-lg max-h-48 overflow-y-auto z-10 flex flex-col">
-            <button v-for="(name, code) in languages" :key="code" @click="selectLanguage(code)" class="block w-full text-left px-4 py-2 hover:bg-gray-700 transition duration-200">
-              {{ name }}
-            </button>
-          </div>
-        </transition>
-      </div>
+  <button @click="toggleDropdown($event)" class="language-toggle-btn flex items-center gap-2 px-4 py-2 bg-gray-800 rounded-lg text-sm font-medium text-white hover:bg-gray-700 transition-colors">
+    {{ currentLanguageName }}
+    <svg class="language-icon w-4 h-4 transition-transform" :class="{ 'rotate-180': showDropdown }" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+    </svg>
+  </button>
+  <transition name="dropdown">
+    <div v-if="showDropdown" class="language-dropdown absolute right-0 w-64 bg-gray-800 rounded-lg shadow-xl py-2 z-10 max-h-[80vh] overflow-y-auto border border-gray-700"
+         :class="dropdownPosition === 'top' ? 'bottom-full mb-2' : 'top-full mt-2'">
+      <button 
+        v-for="(name, code) in languages" 
+        :key="code" 
+        @click="selectLanguage(code)" 
+        class="language-option block w-full text-left px-4 py-3 text-sm text-gray-200 hover:bg-gray-700 hover:text-white transition-all duration-200 border-l-2 border-transparent hover:border-blue-400"
+        :class="{ 'bg-gradient-to-r from-blue-600 to-blue-500 text-white shadow-md border-l-2 border-blue-300': code === locale }"
+      >
+        {{ name }}
+      </button>
+    </div>
+  </transition>
+</div>
     </header>
 
     <main>
@@ -44,7 +54,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import ReportList from './components/ReportList.vue'
 import DeviceInfoPanel from './components/DeviceInfoPanel.vue'
@@ -76,10 +86,21 @@ const languages = {
 }
 const currentLanguageName = computed(() => languages[locale.value] || 'English')
 
-function toggleDropdown() {
-  showDropdown.value = !showDropdown.value
-}
+const dropdownPosition = ref('bottom')
 
+function toggleDropdown(event: MouseEvent) {
+  showDropdown.value = !showDropdown.value
+  if (showDropdown.value) {
+    nextTick(() => {
+      const button = event.target as HTMLElement
+      const dropdown = button.nextElementSibling as HTMLElement
+      const buttonRect = button.getBoundingClientRect()
+      const dropdownHeight = dropdown.offsetHeight
+      const spaceBelow = window.innerHeight - buttonRect.bottom
+      dropdownPosition.value = spaceBelow < dropdownHeight ? 'top' : 'bottom'
+    })
+  }
+}
 function selectLanguage(lang: string) {
   locale.value = lang
   showDropdown.value = false
@@ -188,8 +209,8 @@ header {
   padding: 10px 16px;
   background: #1d1d1d;
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
-  align-items: center;
 }
 
 header h1 {
@@ -204,31 +225,59 @@ header h1 {
 }
 
 .languages {
-  display: flex;
-  gap: 4px;
+  position: relative;
   margin-left: 16px;
+  margin-right: 16px;
 }
-
-.languages button {
-  background: #2a2a2a;
-  border: none;
-  color: #ccc;
-  padding: 4px 8px;
-  font-size: 11px;
-  border-radius: 4px;
-  cursor: pointer;
+.dropdown-enter-active, .dropdown-leave-active {
+  transition: opacity 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+.dropdown-enter-from, .dropdown-leave-to {
+  opacity: 0;
+  transform: translateY(-15px) scale(0.95);
+}
+.language-option {
+  transition: all 0.3s ease-in-out;
+}
+.language-option:hover {
+  transform: scale(1.03);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+.language-option:active {
+  transform: scale(0.97);
+  transition: transform 0.1s ease-in-out;
+}
+.language-toggle-btn {
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+  background: linear-gradient(to bottom, #3a3a3a, #2a2a2a);
+  color: white;
   font-weight: 500;
-  transition: background .15s, color .15s;
+  border: 1px solid #444;
 }
 
-.languages button:hover {
-  background: #333;
-  color: #fff;
+.language-dropdown {
+  border-radius: 12px;
+  box-shadow: 0 6px 20px rgba(0,0,0,0.35);
+  background: #1a1a1a;
+  border: 1px solid #333;
 }
 
-.languages button.active {
-  background: #2658d8;
-  color: #fff;
+.language-option {
+  border-radius: 8px;
+  margin: 4px;
+  padding: 8px 12px;
+  transition: all 0.2s ease;
+}
+
+.language-option:hover {
+  background-color: #2a2a2a;
+  transform: translateX(2px);
+}
+
+.language-option.bg-gradient-to-r {
+  box-shadow: 0 2px 8px rgba(59,130,246,0.4);
+  border-left: 2px solid #4d8bf8;
 }
 
 main {

--- a/src/components/DeviceInfoPanel.vue
+++ b/src/components/DeviceInfoPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="device" class="device-info">
-    <h3>Device Info</h3>
+    <h3>{{ $t('deviceInfo') }}</h3>
     <table>
       <tbody>
         <tr v-for="(v, k) in device" :key="k">
@@ -10,7 +10,7 @@
       </tbody>
     </table>
   </div>
-  <div v-else class="device-info-empty">No device.json</div>
+  <div v-else class="device-info-empty">{{ $t('noDevice') }}</div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/LogFileTree.vue
+++ b/src/components/LogFileTree.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="log-tree">
-    <h3>Log Files</h3>
+    <h3>{{ $t('logFiles') }}</h3>
     <ul>
       <li v-for="l in logFiles" :key="l.path" :class="{ active: l.path === modelValue }" @click="$emit('update:modelValue', l.path)">
         <div class="row1">

--- a/src/components/LogViewer.vue
+++ b/src/components/LogViewer.vue
@@ -5,7 +5,6 @@
         <input v-model="filter" :placeholder="$t('regexPlaceholder')" />
       </label>
       <button @click="setFilter('WARN')" class="filter-btn bg-yellow-600 hover:bg-yellow-700">{{ $t('warn') }}</button>
-      <button @click="setFilter('ERROR')" class="filter-btn bg-red-600 hover:bg-red-700">{{ $t('error') }}</button>
       <button @click="clearFilter" class="filter-btn bg-gray-600 hover:bg-gray-500">{{ $t('clear') }}</button>
       <span v-if="stats" class="info">{{ $t('linesInfo', { visible: stats.visible, total: stats.total }) }}</span>
       <span v-if="isLarge" class="warn">{{ $t('largeFile') }}</span>

--- a/src/components/LogViewer.vue
+++ b/src/components/LogViewer.vue
@@ -1,15 +1,17 @@
 <template>
   <div class="log-viewer">
     <div class="toolbar">
-      <label>
-        Filter:
-        <input v-model="filter" placeholder="Regex or text" />
+      <label>{{ $t('filter') }}
+        <input v-model="filter" :placeholder="$t('regexPlaceholder')" />
       </label>
-      <span v-if="stats" class="info">{{ stats.visible }} / {{ stats.total }} lines</span>
-      <span v-if="isLarge" class="warn">Large file</span>
+      <button @click="setFilter('WARN')" class="filter-btn bg-yellow-600 hover:bg-yellow-700">{{ $t('warn') }}</button>
+      <button @click="setFilter('ERROR')" class="filter-btn bg-red-600 hover:bg-red-700">{{ $t('error') }}</button>
+      <button @click="clearFilter" class="filter-btn bg-gray-600 hover:bg-gray-500">{{ $t('clear') }}</button>
+      <span v-if="stats" class="info">{{ $t('linesInfo', { visible: stats.visible, total: stats.total }) }}</span>
+      <span v-if="isLarge" class="warn">{{ $t('largeFile') }}</span>
     </div>
     <div ref="editorEl" class="editor"></div>
-    <div v-if="filtering" class="overlay">Filtering...</div>
+    <div v-if="filtering" class="overlay">{{ $t('filtering') }}</div>
   </div>
 </template>
 
@@ -84,6 +86,13 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => { disposeFiltered(); disposeOriginal(); if (debounceHandle) window.clearTimeout(debounceHandle) })
+// In script
+function setFilter(type: string) {
+  filter.value = type
+}
+function clearFilter() {
+  filter.value = ''
+}
 </script>
 
 <style scoped>
@@ -108,4 +117,13 @@ onBeforeUnmount(() => { disposeFiltered(); disposeOriginal(); if (debounceHandle
 .editor { flex:1; min-height:300px; border:1px solid #2c2c2c; border-radius:8px; overflow:hidden; box-shadow:0 0 0 1px #000; }
 .overlay { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.45); font-size:14px; backdrop-filter: blur(2px); }
 .warn { color:#d0a800; font-size:11px; background:#2e2500; padding:2px 6px; border-radius:4px; }
+.filter-btn {
+  color: white;
+  padding: 6px 12px;
+  border-radius: 6px;
+  margin-left: 8px;
+  transition: background 0.2s;
+  font-size: 14px;
+  font-weight: bold;
+}
 </style>

--- a/src/components/LogViewer.vue
+++ b/src/components/LogViewer.vue
@@ -4,8 +4,8 @@
       <label>{{ $t('filter') }}
         <input v-model="filter" :placeholder="$t('regexPlaceholder')" />
       </label>
-      <button @click="setFilter('WARN')" class="filter-btn bg-yellow-600 hover:bg-yellow-700">{{ $t('warn') }}</button>
-      <button @click="clearFilter" class="filter-btn bg-gray-600 hover:bg-gray-500">{{ $t('clear') }}</button>
+      <button @click="setFilter('WARN')" class="filter-btn bg-yellow-400 hover:bg-yellow-500">{{ $t('warn') }}</button>
+      <button @click="clearFilter" class="filter-btn bg-gray-300 hover:bg-gray-400">{{ $t('clear') }}</button>
       <span v-if="stats" class="info">{{ $t('linesInfo', { visible: stats.visible, total: stats.total }) }}</span>
       <span v-if="isLarge" class="warn">{{ $t('largeFile') }}</span>
     </div>
@@ -96,7 +96,7 @@ function clearFilter() {
 
 <style scoped>
 .log-viewer { display:flex; flex-direction:column; height:100%; position:relative; }
-.toolbar { display:flex; gap:16px; align-items:center; font-size:12px; padding:4px 0 6px; }
+.toolbar { display:flex; flex-wrap: wrap; gap:16px; align-items:center; font-size:12px; padding:4px 0 6px; }
 .toolbar label { display:flex; align-items:center; gap:6px; font-weight:500; letter-spacing:.3px; }
 .toolbar input {
   background:#1c1c1c;
@@ -117,12 +117,13 @@ function clearFilter() {
 .overlay { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,.45); font-size:14px; backdrop-filter: blur(2px); }
 .warn { color:#d0a800; font-size:11px; background:#2e2500; padding:2px 6px; border-radius:4px; }
 .filter-btn {
-  color: white;
+  color: #000000; /* Черный текст для лучшей видимости */
   padding: 6px 12px;
   border-radius: 6px;
   margin-left: 8px;
   transition: background 0.2s;
   font-size: 14px;
   font-weight: bold;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1); /* Добавляем тень для глубины */
 }
 </style>

--- a/src/components/ReportList.vue
+++ b/src/components/ReportList.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="report-list">
-    <h3>Reports</h3>
+    <h3>{{ $t('reports') }}</h3>
     <ul>
       <li v-for="r in reports" :key="r.id" :class="{ active: r.id === modelValue }"
         @click="$emit('update:modelValue', r.id)">
         <div class="row1">
           <strong>{{ r.id }}</strong>
           <span v-if="r.device" class="dev">{{ r.device.platform }} {{ r.device.arch }}</span>
-          <small class="logs">({{ r.logs.length }} logs)</small>
+          <small class="logs">({{ $t('logsCount', { count: r.logs.length }) }})</small>
         </div>
         <div v-if="r.lastModified" class="time" :title="new Date(r.lastModified).toLocaleString()">
           {{ new Date(r.lastModified).toLocaleDateString() }}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL Log Viewer",
+  "openFolder": "Ordner öffnen (FS API)",
+  "selectLog": "Wählen Sie eine Protokolldatei zum Anzeigen aus.",
+  "reports": "Berichte",
+  "logFiles": "Protokolldateien",
+  "deviceInfo": "Geräteinformationen",
+  "noDevice": "Keine device.json",
+  "filter": "Filter:",
+  "regexPlaceholder": "Regex oder Text",
+  "linesInfo": "{visible} / {total} Zeilen",
+  "largeFile": "Große Datei",
+  "filtering": "Filtern…",
+  "logsCount": "{count} Log | {count} Logs",
+  "chooseFolder": "Ordner wählen",
+  "chooseZipFiles": "ZIP-Dateien wählen",
+  "warn": "WARNUNG",
+  "error": "FEHLER",
+  "clear": "Löschen"
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL Log Viewer",
+  "openFolder": "Open Folder (FS API)",
+  "selectLog": "Select a log file to view.",
+  "reports": "Reports",
+  "logFiles": "Log Files",
+  "deviceInfo": "Device Info",
+  "noDevice": "No device.json",
+  "filter": "Filter:",
+  "regexPlaceholder": "Regex or text",
+  "linesInfo": "{visible} / {total} lines",
+  "largeFile": "Large file",
+  "filtering": "Filtering...",
+  "logsCount": "{count} log | {count} logs",
+  "chooseFolder": "Choose Folder",
+  "chooseZipFiles": "Choose ZIP Files",
+  "warn": "WARN",
+  "error": "ERROR",
+  "clear": "Clear"
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL Log Viewer",
+  "openFolder": "Open Folder (FS API)",
+  "selectLog": "Select a log file to view.",
+  "reports": "Reports",
+  "logFiles": "Log Files",
+  "deviceInfo": "Device Info",
+  "noDevice": "No device.json",
+  "filter": "Filter:",
+  "regexPlaceholder": "Regex or text",
+  "linesInfo": "{visible} / {total} lines",
+  "largeFile": "Large file",
+  "filtering": "Filtering...",
+  "logsCount": "{count} log | {count} logs",
+  "chooseFolder": "Choose Folder",
+  "chooseZipFiles": "Choose ZIP Files",
+  "warn": "WARN",
+  "error": "ERROR",
+  "clear": "Clear"
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,20 @@
+{
+  "title": "Visor de Logs XMCL",
+  "openFolder": "Abrir Carpeta (FS API)",
+  "selectLog": "Seleccione un archivo de log para ver.",
+  "reports": "Informes",
+  "logFiles": "Archivos de Log",
+  "deviceInfo": "Información del Dispositivo",
+  "noDevice": "No device.json",
+  "filter": "Filtro:",
+  "regexPlaceholder": "Regex o texto",
+  "linesInfo": "{visible} / {total} líneas",
+  "largeFile": "Archivo grande",
+  "filtering": "Filtrando...",
+  "logsCount": "{count} log | {count} logs",
+  "chooseFolder": "Elegir carpeta",
+  "chooseZipFiles": "Elegir archivos ZIP",
+  "warn": "ADVERTENCIA",
+  "error": "ERROR",
+  "clear": "LIMPIAR"
+}

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL ログビューア",
+  "openFolder": "フォルダを開く (FS API)",
+  "selectLog": "ログファイルを選択して表示。",
+  "reports": "レポート",
+  "logFiles": "ログファイル",
+  "deviceInfo": "デバイス情報",
+  "noDevice": "device.json なし",
+  "filter": "フィルタ:",
+  "regexPlaceholder": "正規表現またはテキスト",
+  "linesInfo": "{visible} / {total} 行",
+  "largeFile": "大きなファイル",
+  "filtering": "フィルタリング中...",
+  "logsCount": "{count} ログ | {count} ログ",
+  "chooseFolder": "フォルダを選択",
+  "chooseZipFiles": "ZIPファイルを選択",
+  "warn": "警告",
+  "error": "エラー",
+  "clear": "クリア"
+}

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL Log Viewer",
+  "openFolder": "폴더 열기 (FS API)",
+  "selectLog": "로그 파일을 선택하여 보세요.",
+  "reports": "보고서",
+  "logFiles": "로그 파일",
+  "deviceInfo": "장치 정보",
+  "noDevice": "device.json 없음",
+  "filter": "필터:",
+  "regexPlaceholder": "정규 표현식 또는 텍스트",
+  "linesInfo": "{visible} / {total} 줄",
+  "largeFile": "큰 파일",
+  "filtering": "필터링 중...",
+  "logsCount": "{count} 로그 | {count} 로그",
+  "chooseFolder": "폴더 선택",
+  "chooseZipFiles": "ZIP 파일 선택",
+  "warn": "경고",
+  "error": "오류",
+  "clear": "지우기"
+}

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1,0 +1,20 @@
+{
+  "title": "Przeglądarka Logów XMCL",
+  "openFolder": "Otwórz Folder (FS API)",
+  "selectLog": "Wybierz plik logu do просмотра.",
+  "reports": "Raporty",
+  "logFiles": "Pliki Logów",
+  "deviceInfo": "Informacje o Urządzeniu",
+  "noDevice": "Brak device.json",
+  "filter": "Filtr:",
+  "regexPlaceholder": "Wyrażenie regularne lub tekst",
+  "linesInfo": "{visible} / {total} linii",
+  "largeFile": "Duży plik",
+  "filtering": "Filtrowanie...",
+  "logsCount": "{count} log | {count} logi | {count} logów",
+  "chooseFolder": "Wybierz Folder",
+  "chooseZipFiles": "Wybierz Pliki ZIP",
+  "warn": "OSTRZEŻENIE",
+  "error": "BŁĄD",
+  "clear": "Wyczyść"
+}

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -1,0 +1,20 @@
+{
+  "title": "Visualizador de Logs XMCL",
+  "openFolder": "Abrir Pasta (FS API)",
+  "selectLog": "Selecione um arquivo de log para visualizar.",
+  "reports": "Relatórios",
+  "logFiles": "Arquivos de Log",
+  "deviceInfo": "Informações do Dispositivo",
+  "noDevice": "Nenhum device.json",
+  "filter": "Filtro:",
+  "regexPlaceholder": "Regex ou texto",
+  "linesInfo": "{visible} / {total} linhas",
+  "largeFile": "Arquivo grande",
+  "filtering": "Filtrando...",
+  "logsCount": "{count} log | {count} logs",
+  "chooseFolder": "Escolher Pasta",
+  "chooseZipFiles": "Escolher Arquivos ZIP",
+  "warn": "AVISO",
+  "error": "ERRO",
+  "clear": "Limpar"
+}

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1,0 +1,20 @@
+{
+  "title": "Visualizador de Registos XMCL",
+  "openFolder": "Abrir Pasta (FS API)",
+  "selectLog": "Selecione um ficheiro de registo para ver.",
+  "reports": "Relatórios",
+  "logFiles": "Ficheiros de Registo",
+  "deviceInfo": "Informações do Dispositivo",
+  "noDevice": "Nenhum device.json",
+  "filter": "Filtro:",
+  "regexPlaceholder": "Regex ou texto",
+  "linesInfo": "{visible} / {total} linhas",
+  "largeFile": "Ficheiro grande",
+  "filtering": "A filtrar...",
+  "logsCount": "{count} registo | {count} registos",
+  "chooseFolder": "Escolher Pasta",
+  "chooseZipFiles": "Escolher Ficheiros ZIP",
+  "warn": "AVISO",
+  "error": "ERRO",
+  "clear": "Limpar"
+}

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,0 +1,20 @@
+{
+  "title": "Просмотрщик логов XMCL",
+  "openFolder": "Открыть папку (FS API)",
+  "selectLog": "Выберите файл лога для просмотра.",
+  "reports": "Отчеты",
+  "logFiles": "Файлы логов",
+  "deviceInfo": "Информация об устройстве",
+  "noDevice": "Нет device.json",
+  "filter": "Фильтр:",
+  "regexPlaceholder": "Регулярное выражение или текст",
+  "linesInfo": "{visible} / {total} строк",
+  "largeFile": "Большой файл",
+  "filtering": "Фильтрация…",
+  "logsCount": "{count} лог | {count} лога | {count} логов",
+  "chooseFolder": "Выбрать папку",
+  "chooseZipFiles": "Выбрать ZIP-файлы",
+  "warn": "ПРЕДУПРЕЖДЕНИЕ",
+  "error": "ОШИБКА",
+  "clear": "Очистить"
+}

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -1,0 +1,20 @@
+{
+  "title": "Переглядач логів XMCL",
+  "openFolder": "Відкрити папку (FS API)",
+  "selectLog": "Виберіть файл логу для перегляду.",
+  "reports": "Звіти",
+  "logFiles": "Файли логів",
+  "deviceInfo": "Інформація про пристрій",
+  "noDevice": "Немає device.json",
+  "filter": "Фільтр:",
+  "regexPlaceholder": "Регулярний вираз або текст",
+  "linesInfo": "{visible} / {total} рядків",
+  "largeFile": "Великий файл",
+  "filtering": "Фільтрування…",
+  "logsCount": "{count} лог | {count} лога | {count} логів",
+  "chooseFolder": "Вибрати папку",
+  "chooseZipFiles": "Вибрати ZIP-файли",
+  "warn": "ПОПЕРЕДЖЕННЯ",
+  "error": "ПОМИЛКА",
+  "clear": "Очистити"
+}

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL 日志查看器",
+  "openFolder": "打开文件夹 (FS API)",
+  "selectLog": "选择日志文件查看。",
+  "reports": "报告",
+  "logFiles": "日志文件",
+  "deviceInfo": "设备信息",
+  "noDevice": "无 device.json",
+  "filter": "过滤器:",
+  "regexPlaceholder": "正则表达式或文本",
+  "linesInfo": "{visible} / {total} 行",
+  "largeFile": "大文件",
+  "filtering": "过滤中...",
+  "logsCount": "{count} 个日志 | {count} 个日志",
+  "chooseFolder": "选择文件夹",
+  "chooseZipFiles": "选择ZIP文件",
+  "warn": "警告",
+  "error": "错误",
+  "clear": "清除"
+}

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -1,0 +1,20 @@
+{
+  "title": "XMCL 日誌查看器",
+  "openFolder": "打開文件夾 (FS API)",
+  "selectLog": "選擇日誌文件查看。",
+  "reports": "報告",
+  "logFiles": "日誌文件",
+  "deviceInfo": "設備信息",
+  "noDevice": "無 device.json",
+  "filter": "過濾器:",
+  "regexPlaceholder": "正則表達式或文本",
+  "linesInfo": "{visible} / {total} 行",
+  "largeFile": "大文件",
+  "filtering": "過濾中...",
+  "logsCount": "{count} 個日誌 | {count} 個日誌",
+  "chooseFolder": "選擇文件夾",
+  "chooseZipFiles": "選擇ZIP文件",
+  "warn": "警告",
+  "error": "錯誤",
+  "clear": "清除"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,44 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import './tailwind.css'
+import { createI18n } from 'vue-i18n'
+import en from './locales/en.json'
+import ru from './locales/ru.json'
+import uk from './locales/uk.json'
+import de from './locales/de.json'
+import zhCN from './locales/zh-CN.json'
+import zhTW from './locales/zh-TW.json'
+import pl from './locales/pl.json'
+import enUS from './locales/en-US.json'
+import es from './locales/es.json'
+import ja from './locales/ja.json'
+import ko from './locales/ko.json'
+import ptBR from './locales/pt-BR.json'
+import pt from './locales/pt.json'
 
-createApp(App).mount('#app')
+const messages = { 
+  en, 
+  ru, 
+  uk, 
+  de, 
+  'zh-CN': zhCN, 
+  'zh-TW': zhTW, 
+  pl, 
+  'en-US': enUS, 
+  es, 
+  ja, 
+  ko, 
+  'pt-BR': ptBR, 
+  pt 
+}
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages
+})
+
+createApp(App).use(i18n).mount('#app')
 
 if ('serviceWorker' in navigator) {
 	window.addEventListener('load', () => {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    "./index.html",
+    "./src/**/*.{vue,js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
- Implement multi-language support with 14 locale files
- Add language selector dropdown in UI
- Update components to use translation strings
- Configure tailwind and postcss for styling
- Add vue-i18n dependency and setup i18n instance